### PR TITLE
Make deployment script a little safer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ For routine production deploys on the external web server, use
 [scripts/deploy-release.sh](scripts/deploy-release.sh). It resolves `latest` or
 a specific tag from the public GitHub release URLs, downloads the matching
 tarball and `.sha256` checksum, verifies integrity, and syncs the extracted
-site into the server web root.
+site into the server web root. Existing files with the same paths are
+overwritten, but files already present in the target directory are not deleted.
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/glotaran/glotaran.org/main/scripts/deploy-release.sh -o deploy-release.sh

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -96,7 +96,6 @@ tar -xzf "$archive_path" -C "$staging_dir"
 mkdir -p "$TARGET_DIR"
 rsync_args=(
   -a
-  --delete
 )
 
 if [[ "${DRY_RUN:-0}" == "1" ]]; then


### PR DESCRIPTION
This pull request updates the deployment process documentation and script to clarify and change how files are handled during deployment. The main change is that existing files with the same paths are overwritten, but files in the target directory that are not present in the new release are no longer deleted.

Deployment behavior changes:

* The `--delete` flag was removed from the `rsync` command in `scripts/deploy-release.sh`, so files in the target directory that are not present in the new release will not be deleted during deployment.

Documentation updates:

* The `README.md` was updated to explain that while existing files with the same paths are overwritten during deployment, files already present in the target directory are not deleted.