### PR TITLE
Setup Dependabot, update submodules, and add PR CI workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    target-branch: "dependabot/combined"
+    schedule:
+      interval: weekly
+      day: friday
+      time: "18:00"
+      timezone: Europe/Amsterdam
+    open-pull-requests-limit: 20
+    reviewers:
+      - jsnel
+      - s-weigand
+    assignees:
+      - jsnel
+      - s-weigand
+    groups:
+      node-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    rebase-strategy: disabled
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: "dependabot/combined"
+    schedule:
+      interval: weekly
+      day: friday
+      time: "18:00"
+      timezone: Europe/Amsterdam
+    reviewers:
+      - jsnel
+      - s-weigand
+    assignees:
+      - jsnel
+      - s-weigand
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    rebase-strategy: disabled
+
+  - package-ecosystem: gitsubmodule
+    directory: "/"
+    target-branch: "dependabot/combined"
+    schedule:
+      interval: weekly
+      day: friday
+      time: "18:00"
+      timezone: Europe/Amsterdam

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Install and build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
* Added a `.github/dependabot.yml` file to configure Dependabot for automated updates of npm packages, GitHub Actions, and git submodules. This configuration schedules weekly updates, groups updates by type, assigns reviewers/assignees, and targets a combined update branch.

* Added a `.github/workflows/ci.yml` PR CI workflow that runs `npm ci` + `npm run build` on every pull request (with recursive submodule checkout), so Dependabot PRs and all other PRs get automatic build validation before merge.

Submodule update:

* Updated the `external/glotaran.github.io` submodule to the latest commit

<!-- START COPILOT CODING AGENT TIPS -->
---

⚡ Quickly spin up Copilot coding agent tasks from anywhere on your macOS or Windows machine with [Raycast](https://gh.io/cca-raycast-docs).
